### PR TITLE
Corrected matching of \left( and \right) in LaTEX

### DIFF
--- a/bracketeer.py
+++ b/bracketeer.py
@@ -244,6 +244,10 @@ class BracketeerBracketMatcher(sublime_plugin.TextCommand):
         begin_point = region.begin() - 1
         end_point = region.end()
 
+        # LaTEX: if selection directly preceeds \right, examine the string that includes \right instead of the actual selection
+        if self.view.substr( Region(end_point, min(end_point+6,self.view.size())) ) == '\\right': end_point += 6
+        # /LaTEX
+
         # end_point gets incremented immediately, which skips the first
         # character, *unless* the selection is empty, in which case the
         # inner contents should be selected before scanning past
@@ -261,6 +265,9 @@ class BracketeerBracketMatcher(sublime_plugin.TextCommand):
             c2 = self.view.substr(end_point)
 
             if c2 in closing_search_brackets and c1 == match_map[c2]:
+                # LaTEX: if \left preceeds selection, select it as well
+                if self.view.substr(Region(max(begin_point-5,0), begin_point))=='\left': begin_point -= 5
+                # /LaTEX
                 return Region(begin_point, end_point + 1)
 
         # scan forward searching for a closing bracket.
@@ -300,6 +307,10 @@ class BracketeerBracketMatcher(sublime_plugin.TextCommand):
         # the current point is to the left of the opening bracket,
         # I want it to be to the right.
         begin_point += 1
+
+        # LaTEX: if selection ends in \right, don't select it
+        if self.view.substr( Region(max(end_point-6,0), end_point) ) == '\\right': end_point -= 6
+        # /LaTEX
         return Region(begin_point, end_point)
 
 


### PR DESCRIPTION
![Screenshot](https://f.cloud.github.com/assets/1570168/240961/2aa369dc-896a-11e2-8a16-589128935f4a.png)
